### PR TITLE
Test dataset config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+null/
 test/
 .nextflow*
 work/

--- a/conf/test.config
+++ b/conf/test.config
@@ -20,10 +20,4 @@ params {
     max_time   = '6.h'
 
     // Input data
-    // TODO nf-core: Specify the paths to your test data on nf-core/test-datasets
-    // TODO nf-core: Give any required params for the test so that command line flags are not needed
-    input  = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/samplesheet/samplesheet_test_illumina_amplicon.csv'
-
-    // Fasta references
-    fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/genome/NC_045512.2/GCF_009858895.2_ASM985889v3_genomic.200409.fna.gz'
-}
+    input  = 'https://raw.githubusercontent.com/Arcadia-Science/test-datasets/tree/main/cheese-illumina-metagenomes/*_{1,2}.fq.gz'

--- a/conf/test.config
+++ b/conf/test.config
@@ -20,4 +20,6 @@ params {
     max_time   = '6.h'
 
     // Input data
-    input  = 'https://raw.githubusercontent.com/Arcadia-Science/test-datasets/tree/main/cheese-illumina-metagenomes/*_{1,2}.fq.gz'
+    // TODO add the samplesheet functionality because this won't work for wildcard with https
+    // input  = 'https://raw.githubusercontent.com/Arcadia-Science/test-datasets/tree/main/cheese-illumina-metagenomes/SAMPLESHEET'
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,7 +9,7 @@
 // Global default params, used in configs
 params {
 
-    // Input options
+// Input options
     input                      = null
     single_end                 = false
 
@@ -28,7 +28,7 @@ params {
     keep_phix                               = false
     adapterremoval_trim_quality_stretch     = false
 
-    // Boilerplate options
+// Boilerplate options
     outdir                     = null
     tracedir                   = "${params.outdir}/pipeline_info"
     publish_dir_mode           = 'copy'
@@ -43,8 +43,7 @@ params {
     schema_ignore_params       = 'genomes'
     enable_conda               = false
 
-
-    // Config options
+// Config options
     custom_config_version      = 'master'
     custom_config_base         = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
     config_profile_description = null


### PR DESCRIPTION
This pull request starts the process of adding a test dataset and configuration. The subsampled test files are location in the `Arcadia-Science/test-datasets` repo at https://github.com/Arcadia-Science/test-datasets/tree/main/cheese-illumina-metagenomes. The test config uses a low amount of CPUS/memory to test the overall workflow. 

Currently the workflow can be tested locally with `nextflow run main.nf -profile test,docker --input ../test-datasets/cheese-illumina-metagenomes/"*_{1,2}.fq.gz" --outdir test` where the test fastqs are local because calling from a github repo requires them to be listed in a CSV and I haven't added support for the `samplesheet_csv` module yet. With this test the workflow runs on 2 subset samples in ~7 minutes: 

```
N E X T F L O W  ~  version 22.10.0
Launching `main.nf` [trusting_majorana] DSL2 - revision: 5fa88c2472
executor >  local (10)
[76/c13c37] process > METAGENOMICS:METAGENOMICS_SR:FASTP (vir_1_subsampled)              [100%] 2 of 2 ✔
[8c/81871f] process > METAGENOMICS:METAGENOMICS_SR:SPADES (vir_1_subsampled)             [100%] 2 of 2 ✔
[08/a077b4] process > METAGENOMICS:METAGENOMICS_SR:MAPPING_DEPTH:BOWTIE2_ASSEMBLY_BUI... [100%] 2 of 2 ✔
[d6/c87968] process > METAGENOMICS:METAGENOMICS_SR:MAPPING_DEPTH:BOWTIE2_ASSEMBLY_ALI... [100%] 2 of 2 ✔
[24/d8b178] process > METAGENOMICS:METAGENOMICS_SR:MAPPING_DEPTH:METABAT2_JGISUMMARIZ... [100%] 2 of 2 ✔
Completed at: 21-Oct-2022 10:28:56
Duration    : 7m 13s
CPU hours   : 0.3
Succeeded   : 10
```

To fix in a later pull request(s): 

-  Add support for inputting a samplesheet CSV, as this will also help keep better track of what samples the workflow was run on 
- Add Github CI to test with the subset samples
