### PR TITLE
Reconfigure workflow into separate illumina and nanopore workflows

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -58,7 +58,6 @@ process {
     }
 
     // specific tool configs
-
     withName: METASPADES {
         cpus          = { check_metaspades_cpus (10, task.attempt) }
         memory        = { check_max (75.GB * (2**(task.attempt-1)), 'memory' ) }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -35,3 +35,9 @@ process {
     }
 
 }
+
+if (params.platform == 'illumina') {
+    includeConfig 'modules_illumina.config'
+} else if (params.platform == 'nanopore') {
+    includeConfig 'modules_nanopore.config'
+}

--- a/conf/modules_illumina.config
+++ b/conf/modules_illumina.config
@@ -1,0 +1,24 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Config file for defining DSL2 per module options and publishing paths
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Available keys to override module options:
+        ext.args   = Additional arguments appended to command in module.
+        ext.args2  = Second set of arguments appended to command in module (multi-tool modules).
+        ext.args3  = Third set of arguments appended to command in module (multi-tool modules).
+        ext.prefix = File name prefix for output files.
+----------------------------------------------------------------------------------------
+*/
+
+process {
+    withName: FASTP {
+        ext.args = [
+            "-q ${params.fastp_qualified_quality}",
+            "--cut_front",
+            "--cut_tail",
+            "--cut_mean_quality ${params.fastp_cut_mean_quality}"
+        ].join(' ').trim()
+
+    }
+
+}

--- a/conf/test.config
+++ b/conf/test.config
@@ -21,5 +21,5 @@ params {
 
     // Input data
     input  = 'https://raw.githubusercontent.com/Arcadia-Science/test-datasets/main/metagenomics/illumina/samplesheet_test.csv'
-
+    platform = 'illumina'
 }

--- a/main.nf
+++ b/main.nf
@@ -18,10 +18,26 @@ nextflow.enable.dsl = 2
 
 WorkflowMain.initialise(workflow, params, log)
 
-include {METAGENOMICS_SR} from './workflows/metagenomics-sr'
+if (params.platform == 'illumina') {
+    include { ILLUMINA } from './workflows/illumina'
+} else if (params.platform == 'nanopore') {
+    include { NANOPORE } from './workflows/nanopore'
+}
 
-workflow METAGENOMICS {
-    METAGENOMICS_SR ()
+
+workflow ARCADIASCIENCE_METAGENOMICS {
+    //
+    // WORKFLOW: Illumina processing and assembly
+    //
+    if (params.platform == 'illumina') {
+        ILLUMINA ()
+
+    //
+    // WORKFLOW: Nanopore processing and assembly
+    //
+    } else if (params.platform == 'nanopore') {
+        NANOPORE ()
+    }
 }
 
 /*
@@ -36,7 +52,7 @@ workflow METAGENOMICS {
 // See: https://github.com/nf-core/rnaseq/issues/619
 // without this have to provide -entry
 workflow {
-    METAGENOMICS ()
+    ARCADIASCIENCE_METAGENOMICS ()
 }
 
 /*

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,6 +11,7 @@ params {
 
     // Input options
     input                      = null
+    platform                   = null
     single_end                 = false
 
     // MultiQC options
@@ -20,6 +21,8 @@ params {
     max_multiqc_email_size     = '25.MB'
     multiqc_methods_description = null
 
+    // illumina workflow parameters
+
     // Fastp parameters
     fastp_save_trimmed_fail                 = false
     fastp_qualified_quality                 = 15
@@ -28,7 +31,7 @@ params {
     keep_phix                               = false
     adapterremoval_trim_quality_stretch     = false
 
-    // Reproducibility options for spades
+    // Reproducibility options for metaspades
     metaspades_fix_cpus            = -1
 
     // Boilerplate options

--- a/subworkflows/local/mapping_depth.nf
+++ b/subworkflows/local/mapping_depth.nf
@@ -52,4 +52,5 @@ workflow MAPPING_DEPTH {
     emit:
     grouped_mappings = ch_grouped_mappings
     metabat_depths = ch_metabat_depths
+    versions = ch_versions
 }

--- a/workflows/illumina.nf
+++ b/workflows/illumina.nf
@@ -78,6 +78,7 @@ workflow ILLUMINA {
         ch_assemblies,
         ch_short_reads
     )
+    ch_versions = ch_versions.mix(MAPPING_DEPTH.out.versions)
 
     // dump software versions
     CUSTOM_DUMPSOFTWAREVERSIONS (

--- a/workflows/illumina.nf
+++ b/workflows/illumina.nf
@@ -40,7 +40,7 @@ include { INPUT_CHECK                            } from '../subworkflows/local/i
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-workflow METAGENOMICS_SR {
+workflow ILLUMINA {
     ch_versions = Channel.empty()
 
     // read in samplesheet

--- a/workflows/nanopore.nf
+++ b/workflows/nanopore.nf
@@ -1,0 +1,37 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    VALIDATE INPUTS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+def summary_params = NfcoreSchema.paramsSummaryMap(workflow, params)
+
+// Validate input parameters
+
+WorkflowMetagenomics.initialise(params, log)
+
+// Check input path parameters to see if exist
+def checkPathParamList = [ params.input ]
+for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true) } }
+
+// Check mandatory parameters
+if (params.input) { ch_input = file(params.input) } else { exit 1, 'Input samplesheet not specified!' }
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    IMPORT NF-CORE MODULES
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    IMPORT LOCAL MODULES/SUBWORKFLOWS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RUN MAIN WORKFLOW
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/


### PR DESCRIPTION
This PR starts working towards integrating long reads by making separate illumina and nanopore workflows by requiring a `---platform` parameter. Inspired by the nf-core/viralrecon workflow: https://github.com/nf-core/viralrecon. Currently the test configuration include the illumina platform by default but when the long read tools are ready I will create separate test configs for short and long reads respectively. This PR also fixes parameter usage for fastp which I figured out wasn't specified correctly before. 

The pipeline works with `nextflow run main.nf -profile test,docker --outdir test`
Summary:

```
[b1/b061a1] process > ARCADIASCIENCE_METAGENOMICS:ILLUMINA:INPUT_CHECK:SAMPLESHEET_CHECK (sampleshe... [100%] 1 of 1 ✔
[d1/05d31f] process > ARCADIASCIENCE_METAGENOMICS:ILLUMINA:FASTP (vir_1_T1)                            [100%] 2 of 2 ✔
[5f/4e5e58] process > ARCADIASCIENCE_METAGENOMICS:ILLUMINA:METASPADES (vir_1_T1)                       [100%] 2 of 2 ✔
[32/c10061] process > ARCADIASCIENCE_METAGENOMICS:ILLUMINA:MAPPING_DEPTH:BOWTIE2_ASSEMBLY_BUILD (SP... [100%] 2 of 2 ✔
[a6/84a594] process > ARCADIASCIENCE_METAGENOMICS:ILLUMINA:MAPPING_DEPTH:BOWTIE2_ASSEMBLY_ALIGN (SP... [100%] 2 of 2 ✔
[52/6559f0] process > ARCADIASCIENCE_METAGENOMICS:ILLUMINA:MAPPING_DEPTH:METABAT2_JGISUMMARIZEBAMCO... [100%] 2 of 2 ✔
[b0/a16ef0] process > ARCADIASCIENCE_METAGENOMICS:ILLUMINA:CUSTOM_DUMPSOFTWAREVERSIONS (1)             [100%] 1 of 1 ✔
Completed at: 19-Jan-2023 17:06:28
Duration    : 2m 49s
CPU hours   : 0.1
Succeeded   : 12
```