### PR TITLE
Eam/samtools

### DIFF
--- a/assets/illumina_multiqc_config.yml
+++ b/assets/illumina_multiqc_config.yml
@@ -6,12 +6,15 @@ report_section_order:
     order: -1001
   quast:
     order: -1002
-  "Arcadia-Science-metagenomics-illumina-methods-description":
+  Samtools:
     order: -1003
-  software_versions:
+  "Arcadia-Science-metagenomics-illumina-methods-description":
     order: -1004
-  "Arcadia-Science-metagenomics-summary":
+  software_versions:
     order: -1005
+  "Arcadia-Science-metagenomics-summary":
+    order: -1006
 
 show_analysis_path: False
 export_plots: true
+log_filesize_limit: 2000000000 # read larger files and not automatically skip

--- a/assets/nanopore_multiqc_config.yml
+++ b/assets/nanopore_multiqc_config.yml
@@ -3,15 +3,18 @@ report_comment: >
   analysis pipeline using the Nanopore workflow.
 report_section_order:
   nanostat:
-    order: -1000
-  quast:
     order: -1001
-  "Arcadia-Science-metagenomics-nanopore-methods-description":
+  quast:
     order: -1002
-  software_versions:
+  Samtools:
     order: -1003
-  "Arcadia-Science-metagenomics-summary":
+  "Arcadia-Science-metagenomics-nanopore-methods-description":
     order: -1004
+  software_versions:
+    order: -1005
+  "Arcadia-Science-metagenomics-summary":
+    order: -1006
 
 show_analysis_path: False
 export_plots: true
+log_filesize_limit: 2000000000 # read larger files and not automatically skip

--- a/modules.json
+++ b/modules.json
@@ -25,11 +25,11 @@
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
                     },
-                    "nanoplot": {
-                        "branch": "master",
-                        "git_sha": "3822e04e49b6d89b7092feb3480d744cb5d9986b"
-                    },
                     "porechop/abi": {
+                        "branch": "master",
+                        "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c"
+                    },
+                    "samtools/stats": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c"
                     }

--- a/modules/local/bowtie2_assembly_align.nf
+++ b/modules/local/bowtie2_assembly_align.nf
@@ -14,8 +14,7 @@ process BOWTIE2_ASSEMBLY_ALIGN {
     tuple val(reads_meta), path(reads)
 
     output:
-    tuple val(reads_meta), path("*.bam")                                        , emit: bam
-    tuple val(reads_meta), path("*.bam.bai")                                    , emit: indexed_bam
+    tuple val(reads_meta), path("*.sorted.bam"), path("*.bam.bai")              , emit: sorted_indexed_bam
     tuple val(assembly_meta), val(reads_meta), path("*.bowtie2.log")            , emit: log
     path "versions.yml"                                                         , emit: versions
 
@@ -32,8 +31,8 @@ process BOWTIE2_ASSEMBLY_ALIGN {
         $input \\
         2> "${name}.bowtie2.log" | \
         samtools view -@ "${task.cpus}" -bS | \
-        samtools sort -@ "${task.cpus}" -o "${name}.bam"
-    samtools index "${name}.bam"
+        samtools sort -@ "${task.cpus}" -o "${name}.sorted.bam"
+    samtools index "${name}.sorted.bam"
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         bowtie2: \$(echo \$(bowtie2 --version 2>&1) | sed 's/^.*bowtie2-align-s version //; s/ .*\$//')

--- a/modules/local/nf-core-modified/metabat2/jgisummarizebamcontigdepths/main.nf
+++ b/modules/local/nf-core-modified/metabat2/jgisummarizebamcontigdepths/main.nf
@@ -8,8 +8,7 @@ process METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS {
         'quay.io/biocontainers/metabat2:2.15--h986a166_1' }"
 
     input:
-    tuple val(meta), path(bam)
-    tuple val(meta), path(bai)
+    tuple val(meta), path(bam), path (bai)
 
     output:
     tuple val(meta), path("*.depth.txt.gz"), emit: depth

--- a/modules/local/nf-core-modified/minimap2/align/main.nf
+++ b/modules/local/nf-core-modified/minimap2/align/main.nf
@@ -15,10 +15,9 @@ process MINIMAP2_ALIGN {
     tuple val(index_meta), path(index)
 
     output:
-    tuple val(reads_meta), path("*.sam"),             emit: sam
-    tuple val(reads_meta), path("*.sorted.bam"),      emit: sorted_bam
-    tuple val(reads_meta), path("*.bam.bai"),         emit: indexed_bam
-    path "versions.yml",                        emit: versions
+    tuple val(reads_meta), path("*.sam")                                , emit: sam
+    tuple val(reads_meta), path("*.sorted.bam"), path("*.bam.bai")      , emit: sorted_indexed_bam
+    path "versions.yml"                                                 , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/samtools/stats/main.nf
+++ b/modules/nf-core/samtools/stats/main.nf
@@ -1,0 +1,49 @@
+process SAMTOOLS_STATS {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "bioconda::samtools=1.16.1"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samtools:1.16.1--h6899075_1' :
+        'quay.io/biocontainers/samtools:1.16.1--h6899075_1' }"
+
+    input:
+    tuple val(meta), path(input), path(input_index)
+    tuple val(meta_fasta), path(fasta)
+
+    output:
+    path("*.stats")                 , emit: stats
+    path  "versions.yml"            , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def reference = fasta ? "--reference ${fasta}" : ""
+    """
+    samtools \\
+        stats \\
+        --threads ${task.cpus} \\
+        ${reference} \\
+        ${input} \\
+        > ${prefix}.stats
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.stats
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/samtools/stats/meta.yml
+++ b/modules/nf-core/samtools/stats/meta.yml
@@ -1,0 +1,53 @@
+name: samtools_stats
+description: Produces comprehensive statistics from SAM/BAM/CRAM file
+keywords:
+  - statistics
+  - counts
+  - bam
+  - sam
+  - cram
+tools:
+  - samtools:
+      description: |
+        SAMtools is a set of utilities for interacting with and post-processing
+        short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
+        These files are generated as output by short read aligners like BWA.
+      homepage: http://www.htslib.org/
+      documentation: hhttp://www.htslib.org/doc/samtools.html
+      doi: 10.1093/bioinformatics/btp352
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - input:
+    type: file
+    description: BAM/CRAM file from alignment
+    pattern: "*.{bam,cram}"
+  - input_index:
+    type: file
+    description: BAI/CRAI file from alignment
+    pattern: "*.{bai,crai}"
+  - fasta:
+      type: optional file
+      description: Reference file the CRAM was created with
+      pattern: "*.{fasta,fa}"
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - stats:
+      type: file
+      description: File containing samtools stats output
+      pattern: "*.{stats}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@drpatelh"
+  - "@FriederikeHanssen"

--- a/subworkflows/local/illumina_mapping_depth.nf
+++ b/subworkflows/local/illumina_mapping_depth.nf
@@ -41,7 +41,7 @@ workflow ILLUMINA_MAPPING_DEPTH {
     emit:
     ch_stats         // stats from samtools stats for % mapped
     ch_index         // bowtie2 index
-    ch_align_bam    // sorted, indexed BAMs
+    ch_align_bam     // sorted, indexed BAMs
     ch_depth        // depth table from metabat2
     versions = ch_versions
 }

--- a/subworkflows/local/illumina_mapping_depth.nf
+++ b/subworkflows/local/illumina_mapping_depth.nf
@@ -2,9 +2,10 @@
  * Bowtie2 build and align steps for mapping
  */
 
-include {BOWTIE2_ASSEMBLY_BUILD                          } from '../../modules/local/bowtie2_assembly_build'
-include {BOWTIE2_ASSEMBLY_ALIGN                          } from '../../modules/local/bowtie2_assembly_align'
-include {METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS            } from '../../modules/local/nf-core-modified/metabat2/jgisummarizebamcontigdepths/main'
+include { BOWTIE2_ASSEMBLY_BUILD                          } from '../../modules/local/bowtie2_assembly_build'
+include { BOWTIE2_ASSEMBLY_ALIGN                          } from '../../modules/local/bowtie2_assembly_align'
+include { METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS            } from '../../modules/local/nf-core-modified/metabat2/jgisummarizebamcontigdepths/main'
+include { SAMTOOLS_STATS                                  } from '../../modules/nf-core/samtools/stats/main'
 
 workflow ILLUMINA_MAPPING_DEPTH {
     take:
@@ -22,20 +23,25 @@ workflow ILLUMINA_MAPPING_DEPTH {
     // align reads to index, get sorted and indexed BAM
     BOWTIE2_ASSEMBLY_ALIGN(assemblies, ch_index, reads)
     ch_versions = ch_versions.mix(BOWTIE2_ASSEMBLY_ALIGN.out.versions)
-    ch_align_bam = BOWTIE2_ASSEMBLY_ALIGN.out.bam
-    ch_indexed_bam = BOWTIE2_ASSEMBLY_ALIGN.out.indexed_bam
+    ch_align_bam = BOWTIE2_ASSEMBLY_ALIGN.out.sorted_indexed_bam
     ch_log = BOWTIE2_ASSEMBLY_ALIGN.out.log
 
     // summarize contigs with metabat2
-    METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS (ch_align_bam, ch_indexed_bam)
+    METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS (ch_align_bam)
     ch_versions = ch_versions.mix(METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS.out.versions.first())
     ch_depth = METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS.out.depth
 
+    // samtools stats
+    SAMTOOLS_STATS(ch_align_bam, assemblies)
+    ch_stats = SAMTOOLS_STATS.out.stats
+    ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions)
+
+
     // emit results
     emit:
-    ch_index
-    ch_align_bam
-    ch_indexed_bam
-    ch_depth
+    ch_stats         // stats from samtools stats for % mapped
+    ch_index         // bowtie2 index
+    ch_align_bam    // sorted, indexed BAMs
+    ch_depth        // depth table from metabat2
     versions = ch_versions
 }

--- a/subworkflows/local/illumina_mapping_depth.nf
+++ b/subworkflows/local/illumina_mapping_depth.nf
@@ -36,7 +36,6 @@ workflow ILLUMINA_MAPPING_DEPTH {
     ch_stats = SAMTOOLS_STATS.out.stats
     ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions)
 
-
     // emit results
     emit:
     ch_stats         // stats from samtools stats for % mapped

--- a/subworkflows/local/nanopore_mapping_depth.nf
+++ b/subworkflows/local/nanopore_mapping_depth.nf
@@ -1,9 +1,10 @@
 // Minimap2 subworkflow to index an assembly and map reads to the assembly
 
 
-include { MINIMAP2_INDEX }                          from '../../modules/nf-core/minimap2/index'
-include { MINIMAP2_ALIGN }                          from '../../modules/local/nf-core-modified/minimap2/align'
+include { MINIMAP2_INDEX                       }    from '../../modules/nf-core/minimap2/index'
+include { MINIMAP2_ALIGN                       }    from '../../modules/local/nf-core-modified/minimap2/align'
 include { METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS }    from '../../modules/local/nf-core-modified/metabat2/jgisummarizebamcontigdepths'
+include { SAMTOOLS_STATS                       }    from '../../modules/nf-core/samtools/stats/main'
 
 workflow NANOPORE_MAPPING_DEPTH {
     take:
@@ -22,20 +23,24 @@ workflow NANOPORE_MAPPING_DEPTH {
     MINIMAP2_ALIGN(reads, ch_index)
     ch_versions = ch_versions.mix(MINIMAP2_ALIGN.out.versions)
     ch_align_sam = MINIMAP2_ALIGN.out.sam
-    ch_align_bam = MINIMAP2_ALIGN.out.sorted_bam
-    ch_align_index = MINIMAP2_ALIGN.out.indexed_bam
+    ch_align_bam = MINIMAP2_ALIGN.out.sorted_indexed_bam
 
     // get depth
-    METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS(ch_align_bam, ch_align_index)
+    METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS(ch_align_bam)
     ch_versions = ch_versions.mix(METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS.out.versions.first())
     ch_depth = METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS.out.depth
+
+    // get samtools stats
+    SAMTOOLS_STATS(ch_align_bam, assembly)
+    ch_stats = SAMTOOLS_STATS.out.stats
+    ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions)
 
     emit:
     ch_index
     ch_align_sam // for polishing with racon
-    ch_align_bam // sorted, indexed BAM file for calculating depth
-    ch_align_index // indexed BAM file for calculating depth
+    ch_align_bam // sorted, indexed BAM file for calculating depth, stats
     ch_depth
+    ch_stats    // stats from samtools stats for % mapped
     versions = ch_versions
 
 }

--- a/workflows/illumina.nf
+++ b/workflows/illumina.nf
@@ -112,6 +112,7 @@ workflow ILLUMINA {
     ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
     ch_multiqc_files = ch_multiqc_files.mix(QUAST.out.results.collect().ifEmpty([]))
     ch_multiqc_files = ch_multiqc_files.mix(FASTP.out.json.collect{it[1]}.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(ILLUMINA_MAPPING_DEPTH.out.ch_stats.collect().ifEmpty([]))
 
     MULTIQC(
         ch_multiqc_files.collect(),

--- a/workflows/nanopore.nf
+++ b/workflows/nanopore.nf
@@ -116,6 +116,7 @@ workflow NANOPORE {
     ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
     ch_multiqc_files = ch_multiqc_files.mix(NANOPLOT.out.txt.collect().ifEmpty([]))
     ch_multiqc_files = ch_multiqc_files.mix(QUAST.out.results.collect().ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(NANOPORE_MAPPING_DEPTH.out.ch_stats.collect().ifEmpty([]))
 
     MULTIQC(
         ch_multiqc_files.collect(),


### PR DESCRIPTION
This pull request adds `samtools stats` and multiqc reporting to get % of reads mapped to assembly and other alignment stats per sample. You can see an example of the added samtools section in the attached multiqc report for long reads, and this is added for the illumina workflow as well. 
[MultiQC Report.pdf](https://github.com/Arcadia-Science/metagenomics/files/10727084/MultiQC.Report.pdf)
