### PR TITLE
Sourmash gather/taxonomy updates

### DIFF
--- a/bin/check_sourmash_dbs.py
+++ b/bin/check_sourmash_dbs.py
@@ -4,47 +4,52 @@ import os
 import csv
 import argparse
 
+
 def check_csv_file(csv_file_path):
     valid_rows = []
-    with open(csv_file_path, 'r') as csv_file:
+    with open(csv_file_path, "r") as csv_file:
         csv_reader = csv.DictReader(csv_file)
         for row in csv_reader:
             is_valid = True
             for key, value in row.items():
-                if ' ' in value:
-                    print(f'Error: {key} column contains a space.')
+                if " " in value:
+                    print(f"Error: {key} column contains a space.")
                     is_valid = False
                     break
-            if not os.path.isfile(row['database_path']):
+            if not os.path.isfile(row["database_path"]):
                 print(f'Error: {row["database_path"]} does not exist.')
                 is_valid = False
-            if not os.path.isfile(row['lineage_path']):
+            if not os.path.isfile(row["lineage_path"]):
                 print(f'Error: {row["lineage_path"]} does not exist.')
                 is_valid = False
-            if not row['lineage_path'].endswith('.csv'):
+            if not row["lineage_path"].endswith(".csv"):
                 print(f'Error: {row["lineage_path"]} does not end with .csv')
                 is_valid = False
             if is_valid:
                 valid_rows.append(row)
     return valid_rows
 
+
 def main():
-    parser = argparse.ArgumentParser(description='Validate CSV file')
-    parser.add_argument('csv_file', type=str, help='Path to CSV file')
-    parser.add_argument('-o', '--output', type=str, help='Path to output validated CSV file', default='valid_databases.csv')
+    parser = argparse.ArgumentParser(description="Validate CSV file")
+    parser.add_argument("csv_file", type=str, help="Path to CSV file")
+    parser.add_argument(
+        "-o", "--output", type=str, help="Path to output validated CSV file", default="valid_databases.csv"
+    )
     args = parser.parse_args()
 
     csv_file_path = args.csv_file
     output_file_path = args.output
     valid_rows = check_csv_file(csv_file_path)
     if valid_rows:
-        with open(output_file_path, 'w', newline='') as csv_file:
-            fieldnames = ['database', 'database_path', 'lineage_path']
+        with open(output_file_path, "w", newline="") as csv_file:
+            fieldnames = ["database", "database_path", "lineage_path"]
             csv_writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
             csv_writer.writeheader()
             for row in valid_rows:
                 csv_writer.writerow(row)
-        print(f'Valid databases written to {output_file_path}')
+        print(f"Valid databases written to {output_file_path}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/bin/check_sourmash_dbs.py
+++ b/bin/check_sourmash_dbs.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import os
+import csv
+import argparse
+
+def check_csv_file(csv_file_path):
+    valid_rows = []
+    with open(csv_file_path, 'r') as csv_file:
+        csv_reader = csv.DictReader(csv_file)
+        for row in csv_reader:
+            is_valid = True
+            for key, value in row.items():
+                if ' ' in value:
+                    print(f'Error: {key} column contains a space.')
+                    is_valid = False
+                    break
+            if not os.path.isfile(row['database_path']):
+                print(f'Error: {row["database_path"]} does not exist.')
+                is_valid = False
+            if not os.path.isfile(row['lineage_path']):
+                print(f'Error: {row["lineage_path"]} does not exist.')
+                is_valid = False
+            if not row['lineage_path'].endswith('.csv'):
+                print(f'Error: {row["lineage_path"]} does not end with .csv')
+                is_valid = False
+            if is_valid:
+                valid_rows.append(row)
+    return valid_rows
+
+def main():
+    parser = argparse.ArgumentParser(description='Validate CSV file')
+    parser.add_argument('csv_file', type=str, help='Path to CSV file')
+    parser.add_argument('-o', '--output', type=str, help='Path to output validated CSV file', default='valid_databases.csv')
+    args = parser.parse_args()
+
+    csv_file_path = args.csv_file
+    output_file_path = args.output
+    valid_rows = check_csv_file(csv_file_path)
+    if valid_rows:
+        with open(output_file_path, 'w', newline='') as csv_file:
+            fieldnames = ['database', 'database_path', 'lineage_path']
+            csv_writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+            csv_writer.writeheader()
+            for row in valid_rows:
+                csv_writer.writerow(row)
+        print(f'Valid databases written to {output_file_path}')
+
+if __name__ == '__main__':
+    main()

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -38,6 +38,10 @@ process {
         ext.args = "-k 31"
     }
 
+    withName: SOURMASH_GATHER {
+        ext.args = "-k 31"
+    }
+
 
 }
 

--- a/conf/test_illumina.config
+++ b/conf/test_illumina.config
@@ -20,6 +20,7 @@ params {
     max_time   = '6.h'
 
     // Input data
-    input  = 'https://raw.githubusercontent.com/Arcadia-Science/test-datasets/main/metagenomics/illumina/samplesheet_test.csv'
-    platform = 'illumina'
+    input           = 'https://raw.githubusercontent.com/Arcadia-Science/test-datasets/main/metagenomics/illumina/samplesheet_test.csv'
+    platform        = 'illumina'
+    sourmash_dbs    = 'https://raw.githubusercontent.com/Arcadia-Science/test-datasets/main/metagenomics/sourmash_dbs/sourmash_dbs_test.csv'
 }

--- a/conf/test_nanopore.config
+++ b/conf/test_nanopore.config
@@ -20,6 +20,7 @@ params {
     max_time   = '6.h'
 
     // Input data
-    input    = 'https://raw.githubusercontent.com/Arcadia-Science/test-datasets/main/metagenomics/ont/samplesheet_test.csv'
-    platform = 'nanopore'
+    input           = 'https://raw.githubusercontent.com/Arcadia-Science/test-datasets/main/metagenomics/ont/samplesheet_test.csv'
+    platform        = 'nanopore'
+    sourmash_dbs    = 'https://raw.githubusercontent.com/Arcadia-Science/test-datasets/main/metagenomics/sourmash_dbs/sourmash_dbs_test.csv'
 }

--- a/modules/local/check_sourmash_dbs.nf
+++ b/modules/local/check_sourmash_dbs.nf
@@ -1,0 +1,30 @@
+process CHECK_SOURMASH_DBS {
+    tag "$sourmash_dbs_csv"
+
+    conda "conda-forge::python=3.9--1"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/python:3.9--1' :
+        'quay.io/biocontainers/python:3.9--1' }"
+
+    input:
+    path sourmash_dbs_csv
+
+    output:
+    path '*.csv'       , emit: csv
+    path "versions.yml" , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+
+    """
+    check_sourmash_dbs.py \\
+        $sourmash_dbs_csv \\
+        -o sourmash_dbs.valid.csv
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | sed 's/Python //g')
+    END_VERSIONS
+    """
+}

--- a/modules/local/nf-core-modified/sourmash/gather/main.nf
+++ b/modules/local/nf-core-modified/sourmash/gather/main.nf
@@ -10,7 +10,7 @@ process SOURMASH_GATHER {
 
     input:
     tuple val(meta), path(signature)
-    tuple val(meta_db), path(database)
+    path(database)
     val seqtype
     val save_unassigned
     val save_matches_sig

--- a/modules/local/nf-core-modified/sourmash/gather/main.nf
+++ b/modules/local/nf-core-modified/sourmash/gather/main.nf
@@ -2,6 +2,7 @@ process SOURMASH_GATHER {
     tag "$meta_database.database"
     label 'process_low'
     // bumped up version
+    // added seqtype and modified input channel
 
     conda "bioconda::sourmash=4.6.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -30,7 +31,7 @@ process SOURMASH_GATHER {
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}.${seqtype}"
+    def prefix = task.ext.prefix ?: "${meta.id}.${seqtype}.${meta_database}"
     def unassigned  = save_unassigned   ? "--output-unassigned ${prefix}_unassigned.sig.zip" : ''
     def matches     = save_matches_sig  ? "--save-matches ${prefix}_matches.sig.zip"         : ''
     def prefetch    = save_prefetch     ? "--save-prefetch ${prefix}_prefetch.sig.zip"       : ''

--- a/modules/local/nf-core-modified/sourmash/gather/main.nf
+++ b/modules/local/nf-core-modified/sourmash/gather/main.nf
@@ -10,7 +10,8 @@ process SOURMASH_GATHER {
 
     input:
     tuple val(meta), path(signature)
-    path(database)
+    tuple val(meta_db), path(database)
+    val seqtype
     val save_unassigned
     val save_matches_sig
     val save_prefetch
@@ -30,7 +31,7 @@ process SOURMASH_GATHER {
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def prefix = task.ext.prefix ?: "${meta.id}.${seqtype}"
     def unassigned  = save_unassigned   ? "--output-unassigned ${prefix}_unassigned.sig.zip" : ''
     def matches     = save_matches_sig  ? "--save-matches ${prefix}_matches.sig.zip"         : ''
     def prefetch    = save_prefetch     ? "--save-prefetch ${prefix}_prefetch.sig.zip"       : ''
@@ -39,7 +40,7 @@ process SOURMASH_GATHER {
     """
     sourmash gather \\
         $args \\
-        --output ${prefix}.csv.gz \\
+        --output ${prefix}.csv \\
         ${unassigned} \\
         ${matches} \\
         ${prefetch} \\
@@ -47,6 +48,7 @@ process SOURMASH_GATHER {
         ${signature} \\
         ${database}
 
+    touch ${prefix}.csv
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         sourmash: \$(echo \$(sourmash --version 2>&1) | sed 's/^sourmash //' )

--- a/modules/local/nf-core-modified/sourmash/gather/main.nf
+++ b/modules/local/nf-core-modified/sourmash/gather/main.nf
@@ -1,5 +1,5 @@
 process SOURMASH_GATHER {
-    tag "$meta.id"
+    tag "$meta_database.database"
     label 'process_low'
     // bumped up version
 
@@ -9,8 +9,7 @@ process SOURMASH_GATHER {
         'quay.io/biocontainers/sourmash:4.6.1--hdfd78af_0' }"
 
     input:
-    tuple val(meta), path(signature)
-    path(database)
+    tuple val(meta), path(signature), val(meta_database), path(database_path)
     val seqtype
     val save_unassigned
     val save_matches_sig
@@ -46,7 +45,7 @@ process SOURMASH_GATHER {
         ${prefetch} \\
         ${prefetchcsv} \\
         ${signature} \\
-        ${database}
+        ${database_path}
 
     touch ${prefix}.csv
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/nf-core-modified/sourmash/taxannotate/main.nf
+++ b/modules/local/nf-core-modified/sourmash/taxannotate/main.nf
@@ -9,7 +9,7 @@ process SOURMASH_TAXANNOTATE {
 
     input:
     tuple val(meta), path(gather_results)
-    path(taxonomy)
+    tuple val(database_meta), path(taxonomy)
     val seqtype
 
     output:

--- a/modules/local/nf-core-modified/sourmash/taxannotate/main.nf
+++ b/modules/local/nf-core-modified/sourmash/taxannotate/main.nf
@@ -1,0 +1,40 @@
+process SOURMASH_TAXANNOTATE {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "bioconda::sourmash=4.6.1"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/sourmash:4.6.1--hdfd78af_0':
+        'quay.io/biocontainers/sourmash:4.6.1--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(gather_results)
+    path(taxonomy)
+    val seqtype
+
+    output:
+    tuple val(meta), path("*.with-lineages.csv.gz"), emit: result
+    path "versions.yml"                            , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    """
+    sourmash \\
+        tax annotate \
+        $args \\
+        --gather-csv ${gather_results} \\
+        --taxonomy ${taxonomy} \\
+        --output-dir "."
+
+    ## Compress output
+    gzip --no-name *.with-lineages.csv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        sourmash: \$(echo \$(sourmash --version 2>&1) | sed 's/^sourmash //' )
+    END_VERSIONS
+    """
+}

--- a/modules/local/nf-core-modified/sourmash/taxannotate/meta.yml
+++ b/modules/local/nf-core-modified/sourmash/taxannotate/meta.yml
@@ -1,0 +1,59 @@
+name: "sourmash_taxannotate"
+description: Annotate list of metagenome members (based on sourmash signature matches) with taxonomic information.
+keywords:
+  - fracminhash sketch
+  - signature
+  - kmer
+  - containment
+  - sourmash
+  - genomics
+  - metagenomics
+  - taxonomic classification
+  - taxonomic profiling
+tools:
+  - "sourmash":
+      description: Compute and compare FracMinHash signatures for DNA data sets.
+      homepage: https://sourmash.readthedocs.io/
+      documentation: https://sourmash.readthedocs.io/
+      tool_dev_url: https://github.com/sourmash-bio/sourmash
+      doi: "10.21105/joss.00027"
+      licence: ["BSD-3-clause"]
+
+## Description of all of the variables used as input
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - gather_results:
+      type: file
+      description: |
+        Mandatory table with signatures classified as belonging to any of the genomes
+        in the sourmash database(s), result of `sourmash gather` command.
+  - taxonomy:
+      type: file
+      description: One or more databases with lineages (in CSV format, Mandatory)
+
+## Description of all of the variables used as output
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - result:
+      type: file
+      description: |
+        Table with signatures classified as belonging to any of the genomes
+        in the sourmash database(s) with an additional 'lineage' column
+        containing the taxonomic information for each database match.
+      pattern: "*{csv.gz}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+
+authors:
+  - "@vmikk"
+  - "@taylorreiter"

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,6 +12,7 @@ params {
     // Input options
     input                      = null
     platform                   = null
+    sourmash_dbs               = null
     single_end                 = false
 
     // MultiQC options

--- a/subworkflows/local/sourmash_dbs_check.nf
+++ b/subworkflows/local/sourmash_dbs_check.nf
@@ -2,37 +2,61 @@
 // Check input sourmash CSV and create two channels: DB and lineage channels each have the database name since are callled in different sourmash subcommands
 //
 
-include { CHECK_SOURMASH_DBS } from '../../modules/local/check_sourmash_dbs'
+include { CHECK_SOURMASH_DBS as CHECK_DBS       } from '../../modules/local/check_sourmash_dbs'
+include { CHECK_SOURMASH_DBS as CHECK_LINEAGES  } from '../../modules/local/check_sourmash_dbs'
 
 workflow SOURMASH_DBS_CHECK {
     take:
     sourmash_dbs_csv // file: /path/to/samplesheet.csv
 
     main:
-    CHECK_SOURMASH_DBS (sourmash_dbs_csv)
+    CHECK_DBS(sourmash_dbs_csv)
         .csv
         .splitCsv ( header:true, sep:',' )
-        .map { create_sourmash_channel(it) }
+        .map { create_sourmash_dbs_channel(it) }
         .set { sourmash_databases }
+
+    CHECK_LINEAGES(sourmash_dbs_csv)
+        .csv
+        .splitCsv ( header:true, sep:',' )
+        .map { create_sourmash_lineages_channel(it) }
+        .set { sourmash_lineages }
 
     emit:
     sourmash_databases
-    versions = CHECK_SOURMASH_DBS.out.versions
+    sourmash_lineages
+    versions = CHECK_DBS.out.versions
 }
 
 // Function to get list of [ meta, [database_path,lineage_path] ]
-def create_sourmash_channel(LinkedHashMap row) {
+def create_sourmash_dbs_channel(LinkedHashMap row) {
     // create meta map
     def meta = [:]
     meta.database         = row.database
 
     // add path(s) of the fastq file(s) to the meta map
-    def sourmash_meta = []
+    def sourmash_dbs_meta = []
 
     if (!file(row.database_path).exists()) {
         exit 1, "ERROR: Please check input sourmash database CSV -> sourmash database does not exist!\n${row.database_path}"
     } else {
-        sourmash_meta = [ meta, [file(row.database_path)]]
+        sourmash_dbs_meta = [ meta, [file(row.database_path)]]
     }
-    return sourmash_meta
+    return sourmash_dbs_meta
+}
+
+def create_sourmash_lineages_channel(LinkedHashMap row) {
+    // create meta map
+    def meta = [:]
+    meta.database         = row.database
+
+    // add path(s) of the fastq file(s) to the meta map
+    def sourmash_lineages_meta = []
+
+    if (!file(row.lineage_path).exists()) {
+        exit 1, "ERROR: Please check input sourmash database CSV -> sourmash lineage CSV does not exist!\n${row.lineage_path}"
+    } else {
+        sourmash_lineages_meta = [ meta, [file(row.lineage_path)]]
+    }
+    return sourmash_lineages_meta
 }

--- a/subworkflows/local/sourmash_dbs_check.nf
+++ b/subworkflows/local/sourmash_dbs_check.nf
@@ -12,7 +12,7 @@ workflow SOURMASH_DBS_CHECK {
     CHECK_SOURMASH_DBS (sourmash_dbs_csv)
         .csv
         .splitCsv ( header:true, sep:',' )
-        .map { create_fastq_channel(it) }
+        .map { create_sourmash_channel(it) }
         .set { sourmash_databases }
 
     emit:
@@ -21,7 +21,7 @@ workflow SOURMASH_DBS_CHECK {
 }
 
 // Function to get list of [ meta, [database_path,lineage_path] ]
-def create_fastq_channel(LinkedHashMap row) {
+def create_sourmash_channel(LinkedHashMap row) {
     // create meta map
     def meta = [:]
     meta.database         = row.database

--- a/subworkflows/local/sourmash_dbs_check.nf
+++ b/subworkflows/local/sourmash_dbs_check.nf
@@ -1,0 +1,38 @@
+//
+// Check input sourmash CSV and create two channels: DB and lineage channels each have the database name since are callled in different sourmash subcommands
+//
+
+include { CHECK_SOURMASH_DBS } from '../../modules/local/check_sourmash_dbs'
+
+workflow SOURMASH_DBS_CHECK {
+    take:
+    sourmash_dbs_csv // file: /path/to/samplesheet.csv
+
+    main:
+    CHECK_SOURMASH_DBS (sourmash_dbs_csv)
+        .csv
+        .splitCsv ( header:true, sep:',' )
+        .map { create_fastq_channel(it) }
+        .set { sourmash_databases }
+
+    emit:
+    sourmash_databases
+    versions = CHECK_SOURMASH_DBS.out.versions
+}
+
+// Function to get list of [ meta, [database_path,lineage_path] ]
+def create_fastq_channel(LinkedHashMap row) {
+    // create meta map
+    def meta = [:]
+    meta.database         = row.database
+
+    // add path(s) of the fastq file(s) to the meta map
+    def sourmash_meta = []
+
+    if (!file(row.database_path).exists()) {
+        exit 1, "ERROR: Please check input sourmash database CSV -> sourmash database does not exist!\n${row.database_path}"
+    } else {
+        sourmash_meta = [ meta, [file(row.database_path)]]
+    }
+    return sourmash_meta
+}

--- a/subworkflows/local/sourmash_profiling.nf
+++ b/subworkflows/local/sourmash_profiling.nf
@@ -7,6 +7,7 @@ workflow SOURMASH_PROFILING {
     sequences  // tuple val(meta), path(assemblies) OR tuple val(meta), path(reads)
     seqtype
     databases  // path(databases)
+    lineages   // path(lineages)
 
     main:
     ch_versions = Channel.empty()
@@ -15,6 +16,7 @@ workflow SOURMASH_PROFILING {
     SOURMASH_SKETCH(sequences, seqtype)
     ch_signatures = SOURMASH_SKETCH.out.signatures
     ch_versions = ch_versions.mix(SOURMASH_SKETCH.out.versions)
+    view(ch_signatures)
 
     // compare
     ch_compare = ch_signatures
@@ -41,6 +43,10 @@ workflow SOURMASH_PROFILING {
     )
     ch_gather_result = SOURMASH_GATHER.out.result
     ch_versions = ch_versions.mix(SOURMASH_GATHER.out.versions)
+
+    // taxonomy against lineage CSV
+
+    // sourmashconsumr module for running functions to process all files
 
     emit:
     ch_signatures

--- a/subworkflows/local/sourmash_profiling.nf
+++ b/subworkflows/local/sourmash_profiling.nf
@@ -6,9 +6,9 @@ include { SOURMASH_TAXANNOTATE                      }   from '../../modules/loca
 workflow SOURMASH_PROFILING {
     take:
     sequences  // tuple val(meta), path(assemblies) OR tuple val(meta), path(reads)
-    seqtype
-    databases  // tuple val (database_meta), path(database_path)
-    // path(lineages)
+    seqtype    // val(reads) or val(assemblies)
+    databases  // tuple val(database_meta), path(database_path)
+    lineages   // tuple val(database_meta), path(lineage_path)
 
     main:
     ch_versions = Channel.empty()
@@ -48,7 +48,8 @@ workflow SOURMASH_PROFILING {
     ch_versions = ch_versions.mix(SOURMASH_GATHER.out.versions)
 
     // taxonomy against lineage CSV
-    SOURMASH_TAXANNOATE()
+    // first combine correct gather result to lineage CSV with meta database
+    // SOURMASH_TAXANNOTATE(ch_gather_result, lineages, seqtype)
 
     // sourmashconsumr module for running functions to process all files
     // calls a script that outputs an HTML document for Rmarkdown rendering???

--- a/subworkflows/local/sourmash_profiling.nf
+++ b/subworkflows/local/sourmash_profiling.nf
@@ -7,7 +7,7 @@ workflow SOURMASH_PROFILING {
     take:
     sequences  // tuple val(meta), path(assemblies) OR tuple val(meta), path(reads)
     seqtype
-    databases  // path(databases) CSV file of paths to databases to parse for gather
+    databases  // tuple val (database_meta), path(database_path)
     // path(lineages)
 
     main:
@@ -34,8 +34,11 @@ workflow SOURMASH_PROFILING {
     ch_versions = ch_versions.mix(SOURMASH_COMPARE.out.versions)
 
     // gather against database
+    // prep all combinations of input files with databases
+    ch_input_gather = ch_signatures
+        .combine(databases)
 
-    SOURMASH_GATHER(ch_signatures, databases, seqtype,
+    SOURMASH_GATHER(ch_input_gather, seqtype,
         [], // val save_unassigned
         [], // val save_matches_sig
         [], // val save_prefetch

--- a/subworkflows/local/sourmash_profiling.nf
+++ b/subworkflows/local/sourmash_profiling.nf
@@ -6,7 +6,7 @@ workflow SOURMASH_PROFILING {
     take:
     sequences  // tuple val(meta), path(assemblies) OR tuple val(meta), path(reads)
     seqtype
-    databases  // path(databases)
+    databases  // path(databases) CSV file of paths to databases to parse for gather
     // path(lineages)
 
     main:
@@ -16,7 +16,6 @@ workflow SOURMASH_PROFILING {
     SOURMASH_SKETCH(sequences, seqtype)
     ch_signatures = SOURMASH_SKETCH.out.signatures
     ch_versions = ch_versions.mix(SOURMASH_SKETCH.out.versions)
-    view(ch_signatures)
 
     // compare
     ch_compare = ch_signatures
@@ -27,15 +26,15 @@ workflow SOURMASH_PROFILING {
                 meta.id = "k31"
                 [ meta, signatures ]
         }
+
     SOURMASH_COMPARE(ch_compare, seqtype, [], true, true)
     ch_compare_matrix = SOURMASH_COMPARE.out.matrix
     ch_compare_csv = SOURMASH_COMPARE.out.csv
     ch_versions = ch_versions.mix(SOURMASH_COMPARE.out.versions)
 
     // gather against database
-    SOURMASH_GATHER(ch_signatures,
-        databases,
-        seqtype,
+
+    SOURMASH_GATHER(ch_signatures, databases, seqtype,
         [], // val save_unassigned
         [], // val save_matches_sig
         [], // val save_prefetch

--- a/subworkflows/local/sourmash_profiling.nf
+++ b/subworkflows/local/sourmash_profiling.nf
@@ -6,7 +6,7 @@ workflow SOURMASH_PROFILING {
     take:
     sequences  // tuple val(meta), path(assemblies) OR tuple val(meta), path(reads)
     seqtype
-    // databases  // path(databases)
+    databases  // path(databases)
 
     main:
     ch_versions = Channel.empty()
@@ -31,10 +31,21 @@ workflow SOURMASH_PROFILING {
     ch_versions = ch_versions.mix(SOURMASH_COMPARE.out.versions)
 
     // gather against database
+    SOURMASH_GATHER(ch_signatures,
+        databases,
+        seqtype,
+        [], // val save_unassigned
+        [], // val save_matches_sig
+        [], // val save_prefetch
+        []  // val save_prefetch_csv
+    )
+    ch_gather_result = SOURMASH_GATHER.out.result
+    ch_versions = ch_versions.mix(SOURMASH_GATHER.out.versions)
 
     emit:
     ch_signatures
     ch_compare_matrix
     ch_compare_csv
+    ch_gather_result
     versions = ch_versions
 }

--- a/subworkflows/local/sourmash_profiling.nf
+++ b/subworkflows/local/sourmash_profiling.nf
@@ -48,8 +48,10 @@ workflow SOURMASH_PROFILING {
     ch_versions = ch_versions.mix(SOURMASH_GATHER.out.versions)
 
     // taxonomy against lineage CSV
+    SOURMASH_TAXANNOATE()
 
     // sourmashconsumr module for running functions to process all files
+    // calls a script that outputs an HTML document for Rmarkdown rendering???
 
     emit:
     ch_signatures

--- a/subworkflows/local/sourmash_profiling.nf
+++ b/subworkflows/local/sourmash_profiling.nf
@@ -7,7 +7,7 @@ workflow SOURMASH_PROFILING {
     sequences  // tuple val(meta), path(assemblies) OR tuple val(meta), path(reads)
     seqtype
     databases  // path(databases)
-    lineages   // path(lineages)
+    // path(lineages)
 
     main:
     ch_versions = Channel.empty()

--- a/subworkflows/local/sourmash_profiling.nf
+++ b/subworkflows/local/sourmash_profiling.nf
@@ -1,6 +1,7 @@
 include { SOURMASH_SKETCH                           }   from '../../modules/local/nf-core-modified/sourmash/sketch'
 include { SOURMASH_COMPARE                          }   from '../../modules/local/nf-core-modified/sourmash/compare'
 include { SOURMASH_GATHER                           }   from '../../modules/local/nf-core-modified/sourmash/gather'
+include { SOURMASH_TAXANNOTATE                      }   from '../../modules/local/nf-core-modified/sourmash/taxannotate'
 
 workflow SOURMASH_PROFILING {
     take:

--- a/workflows/illumina.nf
+++ b/workflows/illumina.nf
@@ -16,7 +16,7 @@ for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true
 
 // Check mandatory parameters
 if (params.input) { ch_input = file(params.input) } else { exit 1, 'Input samplesheet not specified!' }
-if (params.sourmash_dbs) { ch_sourmash_dbs_file = file(params.sourmash_dbs) } else { exit 1, 'Samplesheet CSV of sourmash DBs not specified!' }
+if (params.sourmash_dbs) { ch_sourmash_dbs = file(params.sourmash_dbs) } else { exit 1, 'List of sourmash databases not provided!' }
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -105,7 +105,7 @@ workflow ILLUMINA {
     SOURMASH_PROFILE_READS (
         ch_short_reads,
         "reads",
-        ch_sourmash_dbs_file
+        ch_sourmash_dbs
     )
 
     // sourmash profiling subworkflow for assemblies

--- a/workflows/illumina.nf
+++ b/workflows/illumina.nf
@@ -101,26 +101,20 @@ workflow ILLUMINA {
     )
     ch_versions = ch_versions.mix(ILLUMINA_MAPPING_DEPTH.out.versions)
 
-    // prepare sourmash dbs from input CSV
-    ch_sourmash_dbs = Channel.fromPath(ch_sourmash_dbs_file)
-        .splitCsv (header:true, sep:",")
-        .map { row ->
-            return [row.subMap(['db_name']), file(row.db_path)]
-            }
     // sourmash profiling subworkflow for reads
     SOURMASH_PROFILE_READS (
         ch_short_reads,
         "reads",
-        ch_sourmash_dbs
+        ch_sourmash_dbs_file
     )
 
     // sourmash profiling subworkflow for assemblies
-    SOURMASH_PROFILE_ASSEMBS (
-        reformatted_assemblies,
-        "assembly",
-        ch_sourmash_dbs
-    )
-    ch_versions = ch_versions.mix(SOURMASH_PROFILE_ASSEMBS.out.versions)
+    // SOURMASH_PROFILE_ASSEMBS (
+    //     reformatted_assemblies,
+    //     "assembly",
+    //     ch_sourmash_dbs_file
+    // )
+    // ch_versions = ch_versions.mix(SOURMASH_PROFILE_ASSEMBS.out.versions)
 
     // dump software versions
     CUSTOM_DUMPSOFTWAREVERSIONS (

--- a/workflows/nanopore.nf
+++ b/workflows/nanopore.nf
@@ -16,7 +16,7 @@ for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true
 
 // Check mandatory parameters
 if (params.input) { ch_input = file(params.input) } else { exit 1, 'Input samplesheet not specified!' }
-if (params.sourmash_dbs) { ch_sourmash_dbs_file = file(sourmash_dbs) } else { exit 1, 'Samplesheet CSV of sourmash DBs not specified!' }
+if (params.sourmash_dbs) { ch_sourmash_dbs_file = file(params.sourmash_dbs) } else { exit 1, 'Samplesheet CSV of sourmash DBs not specified!' }
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -51,8 +51,6 @@ include { QUAST                                          } from '../modules/loca
 include { NANOPLOT                                       } from '../modules/local/nf-core-modified/nanoplot/main'
 include { SOURMASH_PROFILING as SOURMASH_PROFILE_READS   } from '../subworkflows/local/sourmash_profiling'
 include { SOURMASH_PROFILING as SOURMASH_PROFILE_ASSEMBS } from '../subworkflows/local/sourmash_profiling'
-include { SOURMASH_DBS_CHECK                              } from '../subworkflows/local/sourmash_dbs_check'
-
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -114,14 +112,25 @@ workflow NANOPORE {
     )
     ch_versions = ch_versions.mix(MEDAKA.out.versions)
 
+    // prepare sourmash dbs from input CSV
+    ch_sourmash_dbs = Channel.fromPath(ch_sourmash_dbs_file)
+        .splitCsv (header:true, sep:",")
+        .map { row ->
+            return [row.subMap(['db_name']), file(row.db_path)]
+            }
+
+    // sourmash profiling on reads
     SOURMASH_PROFILE_READS (
         ch_reads,
-        "reads"
+        "reads",
+        ch_sourmash_dbs
     )
 
+    // sourmash profiling on assemblies
     SOURMASH_PROFILE_ASSEMBS (
         ch_reformatted_assemblies,
-        "assembly"
+        "assembly",
+        ch_sourmash_dbs
     )
     ch_versions = ch_versions.mix(SOURMASH_PROFILE_ASSEMBS.out.versions)
 

--- a/workflows/nanopore.nf
+++ b/workflows/nanopore.nf
@@ -112,25 +112,18 @@ workflow NANOPORE {
     )
     ch_versions = ch_versions.mix(MEDAKA.out.versions)
 
-    // prepare sourmash dbs from input CSV
-    ch_sourmash_dbs = Channel.fromPath(ch_sourmash_dbs_file)
-        .splitCsv (header:true, sep:",")
-        .map { row ->
-            return [row.subMap(['db_name']), file(row.db_path)]
-            }
-
     // sourmash profiling on reads
     SOURMASH_PROFILE_READS (
         ch_reads,
         "reads",
-        ch_sourmash_dbs
+        ch_sourmash_dbs_file
     )
 
     // sourmash profiling on assemblies
     SOURMASH_PROFILE_ASSEMBS (
         ch_reformatted_assemblies,
         "assembly",
-        ch_sourmash_dbs
+        ch_sourmash_dbs_file
     )
     ch_versions = ch_versions.mix(SOURMASH_PROFILE_ASSEMBS.out.versions)
 

--- a/workflows/nanopore.nf
+++ b/workflows/nanopore.nf
@@ -16,6 +16,7 @@ for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true
 
 // Check mandatory parameters
 if (params.input) { ch_input = file(params.input) } else { exit 1, 'Input samplesheet not specified!' }
+if (params.sourmash_dbs) { ch_sourmash_dbs_file = file(sourmash_dbs) } else { exit 1, 'Samplesheet CSV of sourmash DBs not specified!' }
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -50,6 +51,8 @@ include { QUAST                                          } from '../modules/loca
 include { NANOPLOT                                       } from '../modules/local/nf-core-modified/nanoplot/main'
 include { SOURMASH_PROFILING as SOURMASH_PROFILE_READS   } from '../subworkflows/local/sourmash_profiling'
 include { SOURMASH_PROFILING as SOURMASH_PROFILE_ASSEMBS } from '../subworkflows/local/sourmash_profiling'
+include { SOURMASH_DBS_CHECK                              } from '../subworkflows/local/sourmash_dbs_check'
+
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This pull request adds full support for sourmash gather and stages files for sourmash taxonomy. This includes a script and subworkflow to check an input CSV containing each database and lineage CSV (this will require the user to already have them downloaded or in a bucket somewhere and point to it - I will add this to documentation later) and then funnels those into separate channels for using in `sourmash gather` and `sourmash taxonomy` separately. I have commented out the `sourmash taxannotate` command for now because I: 1) Have to figure out how to deal with empty `sourmash gather` results from no hits to that database when they get passed to `taxannotate` and 2) To line up the correct lineages CSV for the database that was ran against the sample. 

However I might be overcomplicating things because I can't remember if `sourmash gather` and `sourmash taxannotate` can just take the list of databases and lineages against a sample and perform that all in one go or if they have to be separated out in pairwise sample v database fashion. Would appreciate your input @taylorreiter 
